### PR TITLE
added awspublish to gulp file, package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ If you don't want gulp to delete files in the bucket that aren't in your local b
 ```
 To publish to your bucket, just use:
 ```
-gulp publish
+$ gulp publish
 ```

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ a gulp build system.  Some things it'll do for you out of the box:
     * Bootstrap
     * Font Awesome
 * LESS Compilation
-* Angular Template Cache 
+* Angular Template Cache
 * File Watchers with Live Reload
 * Nodemon for server restarts
+* Automate publishing to AWS
 
 **Getting Started**
 
@@ -31,8 +32,8 @@ $ cp .env.sample .env
 $ gulp
 ```
 
-Now open [localhost:3000](http://localhost:3000) in your favorite web browser.  Out of the box you get a build system, 
-live reload, and an angular app started.  All you need to do is drop in your js files and any additional express routes 
+Now open [localhost:3000](http://localhost:3000) in your favorite web browser.  Out of the box you get a build system,
+live reload, and an angular app started.  All you need to do is drop in your js files and any additional express routes
 your app may need.  Some things to note:
 
 * Be mindful about how you name files.  You should name your modules files like:
@@ -41,11 +42,41 @@ your app may need.  Some things to note:
     * Services -> thing.service.js
     * Filter -> thing.filter.js
 * The build system will scan the `app` folder first for any files named `*module.js`, then it looks for any `**/*module.js`
-and finally `**/*.js`.  This will ensure that your angular modules are put first when concatenated into `build/app.js`. 
+and finally `**/*.js`.  This will ensure that your angular modules are put first when concatenated into `build/app.js`.
 * The `/build` folder is the basis for what is served up in the browser.  All of our "built" resources are stuck in this
 folder.  
 * Changes to less, ejs, html templates should trigger a live reload.
 * ES6 is enabled by default, so go crazy wit' all dat new fangled js.
-* Use the [John Papa Style Guide](https://github.com/johnpapa/angular-styleguide) when structuring your angular app.  Don't 
-pile all your states in your main module file, spread them out through out individual modules see the [Welcome Module](https://github.com/Shift3/mean/blob/master/app/welcome/module.js) 
+* Use the [John Papa Style Guide](https://github.com/johnpapa/angular-styleguide) when structuring your angular app.  Don't
+pile all your states in your main module file, spread them out through out individual modules see the [Welcome Module](https://github.com/Shift3/mean/blob/master/app/welcome/module.js)
 for an example.
+
+####How to automate AWS publish
+```
+$ nano ~/.aws/credentials
+```
+Add the following info:
+```
+[default]
+aws_access_key_id = <your access key id>
+aws_secret_access_key = <your secret access key>
+```
+Save the file. AWS will authenticate using this file when publishing to your bucket.
+
+In the gulp file, fill in the missing region and bucket:
+```
+var publisher = awspublish.create({
+  region: '', //example: 'us-west-2'
+  params: {
+    Bucket: '' //example: 'epicapp.s3sandbox.com'
+  }
+});
+```
+If you don't want gulp to delete files in the bucket that aren't in your local build folder, comment out the following line:
+```
+    .pipe(publisher.sync())
+```
+To publish to your bucket, just use:
+```
+gulp publish
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ var gulp = require('gulp'),
   plumber = require('gulp-plumber'),
   babel = require('gulp-babel'),
   iife = require('gulp-iife');
+  awspublish = require('gulp-awspublish');
 
 gulp.task('env', function () {
   env(__dirname + '/.env', {overwrite: true});
@@ -136,6 +137,24 @@ gulp.task('serve', ['env', 'scripts', 'js-deps', 'css-deps', 'templates', 'less'
   });
 
   livereload.listen();
+});
+
+gulp.task('publish', function() {
+  // user must manually create ~/.aws/credentials file, AWS SDK will automatically check for it
+  var publisher = awspublish.create({
+    region: '', //example: 'us-west-2'
+    params: {
+      Bucket: '' //example: 'epicapp.s3sandbox.com'
+    }
+  });
+  return gulp.src('./build/**/*.*')
+    .pipe(publisher.publish())
+    .pipe(publisher.cache())
+    // warning sync will delete files in your bucket that are not in your local folder.
+    .pipe(publisher.sync())
+     // print upload updates to console
+    .pipe(awspublish.reporter());
+      states: ['create', 'update', 'delete']
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "morgan": "^1.6.1",
     "node-env-file": "^0.1.8",
     "gulp-angular-htmlify": "^2.3.0"
+  },
+  "devDependencies": {
+    "gulp-awspublish": "^3.0.1"
   }
 }


### PR DESCRIPTION
Added "[gulp-awspublish](https://github.com/pgherveou/gulp-awspublish)" to the gulp file and to the package.JSON. After a little setup, you can sync your local repo to an AWS bucket with the command `gulp publish`.
