### PR TITLE
gets rid of the Error: transition prevented error

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "angular": "^1.4.9",
-    "angular-ui-router": "^0.2.17",
+    "angular-ui-router": "^0.3.2",
     "babel-preset-es2015": "^6.3.13",
     "body-parser": "^1.14.2",
     "bootstrap": "^3.3.6",


### PR DESCRIPTION
Updates to angular-ui-router 0.3.2 in order to get rid of the `Error: transition` errors